### PR TITLE
Errors Handling

### DIFF
--- a/config/routes/annotations.yaml
+++ b/config/routes/annotations.yaml
@@ -1,3 +1,5 @@
 controllers:
     resource: ../../src/Controller/
     type: annotation
+    defaults:
+        _format: json

--- a/src/Api/ApiProblem.php
+++ b/src/Api/ApiProblem.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Api;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * A wrapper for holding data to be used for a application/problem+json response
+ */
+class ApiProblem
+{
+    private $statusCode;
+    private $type;
+    private $title;
+    private $extraData = [];
+
+    public function __construct($statusCode)
+    {
+        $this->statusCode = $statusCode;
+
+        $type = 'about:blank';
+        $title = isset(Response::$statusTexts[$statusCode])
+            ? Response::$statusTexts[$statusCode]
+            : 'Unknown status code';
+
+        $this->type = $type;
+        $this->title = $title;
+    }
+
+    public function toArray()
+    {
+        return array_merge(
+            array(
+                'status' => $this->statusCode,
+                'type' => $this->type,
+                'title' => $this->title,
+            ),
+            $this->extraData
+        );
+    }
+
+    public function set($name, $value)
+    {
+        $this->extraData[$name] = $value;
+    }
+
+    public function getStatusCode()
+    {
+        return $this->statusCode;
+    }
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}

--- a/src/Controller/ProductsController.php
+++ b/src/Controller/ProductsController.php
@@ -38,7 +38,7 @@ class ProductsController extends Controller
             ->find($id);
 
         if (empty($product)) {
-            return new JsonResponse(['message' => 'Product not found.'], 404);
+            throw $this->createNotFoundException(sprintf('No product found with id "%s"', $id));
         }
 
         return new JsonResponse($product);

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -41,7 +41,7 @@ class UsersController extends Controller
             ->find($id);
 
         if (empty($user)) {
-            return new JsonResponse(['message' => 'User not found.'], 404);
+            throw $this->createNotFoundException(sprintf('No user found with id "%s"', $id));
         }
 
         return new JsonResponse($user);
@@ -61,7 +61,7 @@ class UsersController extends Controller
             ->find($id);
 
         if (empty($user)) {
-            return new JsonResponse(['message' => 'User not found.'], 404);
+            throw $this->createNotFoundException(sprintf('No user found with id "%s"', $id));
         }
 
         $em = $this->getDoctrine()->getManager();

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -3,12 +3,15 @@
 namespace App\Controller;
 
 use App\Entity\User;
+use App\Exception\ApiProblem;
+use App\Exception\ApiProblemException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class UsersController extends Controller
 {
@@ -72,19 +75,42 @@ class UsersController extends Controller
     }
 
     /**
+     * @param Request $request
+     * @param ValidatorInterface $validator
      * @return JsonResponse
      *
      * @Route("/users", name="users_new")
      * @Method("POST")
      */
-    public function new(Request $request)
+    public function new(Request $request, ValidatorInterface $validator)
     {
         $data = json_decode($request->getContent(), true);
+
+        if ($data === null) {
+            $apiProblem = new ApiProblem(400, ApiProblem::TYPE_INVALID_REQUEST_BODY_FORMAT);
+
+            throw new ApiProblemException($apiProblem);
+        }
 
         $user = new User();
         $user->setFirstname($data['firstname']);
         $user->setLastname($data['lastname']);
         $user->setEmail($data['email']);
+
+        $errors = $validator->validate($user);
+
+        if (count($errors) > 0) {
+            $message = [];
+
+            foreach ($errors as $error) {
+                $message[][$error->getPropertyPath()] = $error->getMessage();
+            }
+
+            $apiProblem = new ApiProblem(400, ApiProblem::TYPE_VALIDATION_ERROR);
+            $apiProblem->set('invalid-params', $message);
+
+            throw new ApiProblemException($apiProblem);
+        }
 
         $em = $this->getDoctrine()->getManager();
         $em->persist($user);

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -3,10 +3,13 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Table(name="users")
  * @ORM\Entity(repositoryClass="App\Repository\UserRepository")
+ * @UniqueEntity(fields={"email"})
  */
 class User implements \JsonSerializable
 {
@@ -19,16 +22,20 @@ class User implements \JsonSerializable
 
     /**
      * @ORM\Column(type="string", length=255)
+     * @Assert\NotBlank()
      */
     private $firstname;
 
     /**
      * @ORM\Column(type="string", length=255)
+     * @Assert\NotBlank()
      */
     private $lastname;
 
     /**
      * @ORM\Column(type="string", length=255)
+     * @Assert\NotBlank()
+     * @Assert\Email()
      */
     private $email;
 

--- a/src/EventSubscriber/ApiExceptionSubscriber.php
+++ b/src/EventSubscriber/ApiExceptionSubscriber.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use App\Exception\ApiProblemException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class ApiExceptionSubscriber implements EventSubscriberInterface
+{
+    public function onKernelException(GetResponseForExceptionEvent $event)
+    {
+        $e = $event->getException();
+
+        if (!$e instanceof ApiProblemException) {
+            return;
+        }
+
+        $apiProblem = $e->getApiProblem();
+
+        $response = new JsonResponse(
+            $apiProblem->toArray(),
+            $apiProblem->getStatusCode()
+        );
+        $response->headers->set('Content-Type', 'application/problem+json');
+
+        $event->setResponse($response);
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::EXCEPTION => 'onKernelException'
+        );
+    }
+}

--- a/src/Exception/ApiProblem.php
+++ b/src/Exception/ApiProblem.php
@@ -9,19 +9,34 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ApiProblem
 {
+    const TYPE_VALIDATION_ERROR = 'validation-error';
+    const TYPE_INVALID_REQUEST_BODY_FORMAT = 'invalid-body-format';
+
+    private static $titles = array(
+        self::TYPE_VALIDATION_ERROR => 'Validation error(s) found',
+        self::TYPE_INVALID_REQUEST_BODY_FORMAT => 'Invalid JSON format sent',
+    );
+
     private $statusCode;
     private $type;
     private $title;
     private $extraData = [];
 
-    public function __construct($statusCode)
+    public function __construct($statusCode, $type = null)
     {
         $this->statusCode = $statusCode;
 
-        $type = 'about:blank';
-        $title = isset(Response::$statusTexts[$statusCode])
-            ? Response::$statusTexts[$statusCode]
-            : 'Unknown status code';
+        if ($type === null) {
+            $type = 'about:blank';
+            $title = isset(Response::$statusTexts[$statusCode])
+                ? Response::$statusTexts[$statusCode]
+                : 'Unknown status code.';
+        } else {
+            if (!isset(self::$titles[$type])) {
+                throw new \InvalidArgumentException('No title for type '.$type);
+            }
+            $title = self::$titles[$type];
+        }
 
         $this->type = $type;
         $this->title = $title;

--- a/src/Exception/ApiProblem.php
+++ b/src/Exception/ApiProblem.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Api;
+namespace App\Exception;
 
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Exception/ApiProblemException.php
+++ b/src/Exception/ApiProblemException.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class ApiProblemException extends HttpException
+{
+    private $apiProblem;
+
+    public function __construct(ApiProblem $apiProblem, \Exception $previous = null, array $headers = array(), $code = 0)
+    {
+        $this->apiProblem = $apiProblem;
+        $statusCode = $apiProblem->getStatusCode();
+        $message = $apiProblem->getTitle();
+
+        parent::__construct($statusCode, $message, $previous, $headers, $code);
+    }
+
+    /**
+     * @return ApiProblem
+     */
+    public function getApiProblem(): ApiProblem
+    {
+        return $this->apiProblem;
+    }
+}


### PR DESCRIPTION
Issue #9 
Sends the appropriate HTTP status code to the client for errors and provides a description of the error in the format described in the [RFC 7807](https://tools.ietf.org/html/rfc7807).